### PR TITLE
OT135 124 Configurar logger para grupo C

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -144,3 +144,7 @@ venv
 *.7z
 *.xml
 !requirements.txt
+
+# ignore all "env" folders and all ".env" files
+**/env
+**/.env

--- a/Grupo-Datos-C/logging.cfg
+++ b/Grupo-Datos-C/logging.cfg
@@ -1,0 +1,31 @@
+[loggers]
+keys=root
+
+[handlers]
+keys=consoleHandler,fileHandler
+
+[formatters]
+keys=fileFormatter, consoleFormatter
+
+[logger_root]
+level=DEBUG
+handlers=consoleHandler,fileHandler
+qualname=grupo_c
+
+[handler_consoleHandler]
+class=StreamHandler
+formatter=consoleFormatter
+args=(sys.stdout,)
+
+[handler_fileHandler]
+class=handlers.TimedRotatingFileHandler
+formatter=fileFormatter
+args=('grupo_c.log', 'D', 1, 7)
+
+[formatter_fileFormatter]
+format='%(asctime)s %(levelname)s | %(name)s | %(message)s'
+datefmt='%Y-%m-%d'
+
+[formatter_consoleFormatter]
+format='%(asctime)s %(levelname)s | %(name)s | %(message)s'
+datefmt='%Y-%m-%d'

--- a/Grupo-Datos-C/logging.cfg
+++ b/Grupo-Datos-C/logging.cfg
@@ -20,7 +20,8 @@ args=(sys.stdout,)
 [handler_fileHandler]
 class=handlers.TimedRotatingFileHandler
 formatter=fileFormatter
-args=('grupo_c.log', 'D', 1, 7)
+args=('Grupo_C.log', 'W0')
+# args=('grupo_c.log', 'D', 1, 7)
 
 [formatter_fileFormatter]
 format='%(asctime)s %(levelname)s | %(name)s | %(message)s'

--- a/Grupo-Datos-C/logging.cfg
+++ b/Grupo-Datos-C/logging.cfg
@@ -24,9 +24,9 @@ args=('Grupo_C.log', 'W0')
 # args=('grupo_c.log', 'D', 1, 7)
 
 [formatter_fileFormatter]
-format='%(asctime)s %(levelname)s | %(name)s | %(message)s'
+format='%(asctime)s-%(levelname)s-%(name)s-%(message)s'
 datefmt='%Y-%m-%d'
 
 [formatter_consoleFormatter]
-format='%(asctime)s %(levelname)s | %(name)s | %(message)s'
+format='%(asctime)s-%(levelname)s-%(name)s-%(message)s'
 datefmt='%Y-%m-%d'

--- a/Grupo-Datos-C/main.py
+++ b/Grupo-Datos-C/main.py
@@ -6,4 +6,4 @@ DIR = os.path.dirname(__file__)
 
 logging.config.fileConfig(f'{DIR}/logging.cfg')
 logger = logging.getLogger('logger_grupo_C')
-logger.info('HELLO')
+logger.info('Test message')

--- a/Grupo-Datos-C/main.py
+++ b/Grupo-Datos-C/main.py
@@ -4,7 +4,6 @@ import os
 
 DIR = os.path.dirname(__file__)
 
-
 logging.config.fileConfig(f'{DIR}/logging.cfg')
 logger = logging.getLogger('logger_grupo_C')
 logger.info('HELLO')

--- a/Grupo-Datos-C/main.py
+++ b/Grupo-Datos-C/main.py
@@ -1,0 +1,10 @@
+import logging
+import logging.config
+import os
+
+DIR = os.path.dirname(__file__)
+
+
+logging.config.fileConfig(f'{DIR}/logging.cfg')
+logger = logging.getLogger('logger_grupo_C')
+logger.info('HELLO')


### PR DESCRIPTION
* Añadido y configurado el logger mediante archivo de configuración para el grupo C
* Como solamente hay que trabajar con un archivo rotativo, se utilizó el parámetro 'W0'

https://alkemy-labs.atlassian.net/browse/OT135-124?atlOrigin=eyJpIjoiYWVhZDZhYzQzNTEyNDk5N2JjY2JlOTAwMTk1NGFlNWQiLCJwIjoiaiJ9